### PR TITLE
Correctly import cached packages

### DIFF
--- a/wheelsproxy/models.py
+++ b/wheelsproxy/models.py
@@ -148,7 +148,7 @@ class BackingIndex(models.Model):
         packages_to_update = self.client.iter_updated_packages(serial)
         for package_name, serial in packages_to_update:
             if package_name:
-                if not self.import_package(package_name):
+                if not self.import_package(package_name, ensure_serial=serial):
                     # Nothing imported: remove the package
                     slug = utils.normalize_package_name(package_name)
                     Package.objects.filter(index=self, slug=slug).delete()
@@ -165,10 +165,13 @@ class BackingIndex(models.Model):
         for i in self.itersync():
             pass
 
-    def import_package(self, package_name):
+    def import_package(self, package_name, ensure_serial=None):
         # log.info('importing {} from {}'.format(package_name, self.url))
         try:
-            versions = self.client.get_package_releases(package_name)
+            versions = self.client.get_package_releases(
+                package_name,
+                ensure_serial=ensure_serial,
+            )
         except client.PackageNotFound:
             log.debug('package {} not found on {}'
                       .format(package_name, self.url))

--- a/wheelsproxy/utils.py
+++ b/wheelsproxy/utils.py
@@ -1,4 +1,5 @@
 import re
+import random
 
 import furl
 
@@ -88,3 +89,10 @@ def retry_call(times, func, *args, **kwargs):
                 times -= 1
             else:
                 raise
+
+
+def exponential_backoff(retries, max_wait=None, min_wait=0):
+    wait = random.uniform(2, 4) ** retries
+    if max_wait is not None:
+        wait = min(max_wait, wait)
+    return int(max(min_wait, wait))


### PR DESCRIPTION
The new PyPI infrastructure heavily caches package info endpoints.
It can occur that we receive a notification for an updated package and
we get the package info before its cache is busted, effectively syncing
our local state with the old cached version.

This change ensures that the returned info is up to date with the event
serial which first introduced the change.