### PR TITLE
Update imports to match pip changes

### DIFF
--- a/pip-reqs/pip_reqs/parser.py
+++ b/pip-reqs/pip_reqs/parser.py
@@ -5,9 +5,14 @@ import tempfile
 
 import requests
 
-from pip.req import parse_requirements, RequirementSet
-from pip.download import is_file_url, is_dir_url, is_vcs_url
-from pip.index import PackageFinder
+try:
+    from pip._internal.req import RequirementSet, parse_requirements
+    from pip._internal.download import is_file_url, is_dir_url, is_vcs_url
+    from pip._internal.index import PackageFinder
+except ImportError:
+    from pip.req import parse_requirements, RequirementSet
+    from pip.download import is_file_url, is_dir_url, is_vcs_url
+    from pip.index import PackageFinder
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
This is due to break in the future. We should stop relying on
internal implementation details and provide a more robust way
to parse requirements (or at least better integration tests).